### PR TITLE
Updated namespaces

### DIFF
--- a/HergBotUtilities/DateTimeUtilities/IDateTimeProvider.cs
+++ b/HergBotUtilities/DateTimeUtilities/IDateTimeProvider.cs
@@ -6,7 +6,7 @@
 
 using System;
 
-namespace HergBotUtilities.DateTimeUtilities
+namespace HergBot.Utilities.DateTimeUtilities
 {
     public interface IDateTimeProvider
     {

--- a/HergBotUtilities/DateTimeUtilities/LocalDateTimeProvider.cs
+++ b/HergBotUtilities/DateTimeUtilities/LocalDateTimeProvider.cs
@@ -6,7 +6,7 @@
 
 using System;
 
-namespace HergBotUtilities.DateTimeUtilities
+namespace HergBot.Utilities.DateTimeUtilities
 {
     public class LocalDateTimeProvider : IDateTimeProvider
     {

--- a/HergBotUtilities/DateTimeUtilities/UtcDateTimeProvider.cs
+++ b/HergBotUtilities/DateTimeUtilities/UtcDateTimeProvider.cs
@@ -6,7 +6,7 @@
 
 using System;
 
-namespace HergBotUtilities.DateTimeUtilities
+namespace HergBot.Utilities.DateTimeUtilities
 {
     public class UtcDateTimeProvider : IDateTimeProvider
     {

--- a/HergBotUtilities/EnvironmentUtilities/OperatingSystemUtilities.cs
+++ b/HergBotUtilities/EnvironmentUtilities/OperatingSystemUtilities.cs
@@ -1,6 +1,6 @@
 ﻿using System.Runtime.InteropServices;
 
-namespace HergBotUtilities.EnvironmentUtilities
+namespace HergBot.Utilities.EnvironmentUtilities
 {
     public class OperatingSystemUtilities
     {

--- a/HergBotUtilities_Tests/DateTimeUtilities_Tests/DateTimeProvider_Tests.cs
+++ b/HergBotUtilities_Tests/DateTimeUtilities_Tests/DateTimeProvider_Tests.cs
@@ -8,7 +8,7 @@ using System;
 
 using NUnit.Framework;
 
-using HergBotUtilities.DateTimeUtilities;
+using HergBot.Utilities.DateTimeUtilities;
 
 namespace HergBotUtilities_Tests.DateTimeUtilities_Tests
 {

--- a/HergBotUtilities_Tests/EnvironmentUtilities_Tests/OperatingSystemUtilities_Tests.cs
+++ b/HergBotUtilities_Tests/EnvironmentUtilities_Tests/OperatingSystemUtilities_Tests.cs
@@ -6,7 +6,7 @@
 
 using NUnit.Framework;
 
-using HergBotUtilities.EnvironmentUtilities;
+using HergBot.Utilities.EnvironmentUtilities;
 
 namespace HergBotUtilities_Tests.EnvironmentUtilities_Tests
 {


### PR DESCRIPTION
Updated namespaces to follow new standard separating HergBot and the project purpose. For example, before it was HergBotUtilities and now it is HergBot.Utilities.